### PR TITLE
Debug Tree JSON Reader

### DIFF
--- a/test/test_tree_reader.py
+++ b/test/test_tree_reader.py
@@ -7,7 +7,7 @@ from treescriptify.tree_reader import generate_from_json
 
 
 def wrap_root_dir(inner_dirs: str) -> str:
-	return '{"type":"directory", "name":".", "contents":[' + inner_dirs + ']}'
+	return '[{"type":"directory", "name":".", "contents":[' + inner_dirs + ']}]'
 
 
 def get_src_dir() -> str:

--- a/treescriptify/tree_reader.py
+++ b/treescriptify/tree_reader.py
@@ -1,6 +1,7 @@
 """
 """
 import json
+from sys import exit
 from typing import Generator
 
 from .tree_node_data import TreeNodeData
@@ -10,7 +11,13 @@ def generate_from_json(json_string: str) -> Generator[TreeNodeData, None, None]:
     """Read the JSON string and generate TreeNodeData for all elements.
     """
     full_json = json.loads(json_string)
-    for i in full_json['contents']:
+    if len(full_json) == 1:
+        dirs_dict = full_json[0]
+    elif len(full_json) < 1:
+        exit('Tree Command Failed')
+    else:
+        exit('Additional unexpected data returned from Tree Command.')
+    for i in dirs_dict['contents']:
         for node in _process_node(i, 0):
             yield node
 

--- a/treescriptify/tree_runner.py
+++ b/treescriptify/tree_runner.py
@@ -13,7 +13,7 @@ def get_tree_json(data: InputData) -> str:
         capture_output=True,
         text=True,
         shell=True,
-        timeout=3
+        timeout=5
     )
     #error = result.stderr
     return result.stdout


### PR DESCRIPTION
Fix the Tree Reader JSON processing method.

The expected JSON string provided by tests was incorrect, and did not match the actual output of the Tree Command.

The JSON string is wrapped in square brackets (an array) at the top level.

This change fixes both the tests and the JSON object processing method.

It also increases the timeout on the Tree Command from 3 to 5 seconds, just in case someone wants to run Treescriptify on a large directory.