### PR TITLE
Fix Workflows CodeQL Permissions Warnings

### DIFF
--- a/.github/workflows/ci_run.yml
+++ b/.github/workflows/ci_run.yml
@@ -1,8 +1,6 @@
 # This workflow installs Python dependencies, run lint checks and unit tests
 # Info: https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions
-
 name: Python App lint check and unit test
-
 on:
   push:
     branches: [ main ]
@@ -19,10 +17,14 @@ jobs:
         python-version: [ '3.10', '3.11', '3.12', '3.13' ]
     
     runs-on: ${{ matrix.os }}
+    permissions:
+      contents: read
+    
     steps:
       - uses: actions/checkout@v4
         with:
           persist-credentials: false
+      
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v5
         with:

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -1,7 +1,5 @@
 ## Code Linting
-
 name: Code Linting
-
 on:
   pull_request:
     branches: [main]
@@ -9,13 +7,18 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.12'
+          python-version: '3.13'
           cache: 'pip'
 
       - name: Install Linting Dependencies


### PR DESCRIPTION
CodeQL: actions/missing-workflow-permissions

If a GitHub Actions job or workflow has no explicit permissions set, then the repository permissions are used. Repositories created under organizations inherit the organization permissions. The organizations or repositories created before February 2023 have the default permissions set to read-write. Often these permissions do not adhere to the principle of least privilege and can be reduced to read-only, leaving the write permission only to a specific types as issues: write or pull-requests: write.